### PR TITLE
Re-throw exception that does not have a response

### DIFF
--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -82,7 +82,9 @@ class Proxy implements MiddlewareInterface
         try {
             $response = $this->client->send($request, $this->options);
         } catch (RequestException $exception) {
-            $response = $exception->getResponse();
+            if (!$response = $exception->getResponse()) {
+                throw $exception;
+            }
         }
 
         $response = $response->withBody(new Stream($response->getBody()->detach()));


### PR DESCRIPTION
Sorry it's taken me a while to get round to it, but this PR will re-throw a Guzzle exception that does not have a response. I've put a test in which failed with the error we were seeing before I modified the code to fix it.

Fixes #1 